### PR TITLE
Remove order rules from stylelint config

### DIFF
--- a/packages/stylelint-recommended-scss/index.js
+++ b/packages/stylelint-recommended-scss/index.js
@@ -6,9 +6,6 @@ module.exports = {
   ],
   rules: {
     "max-nesting-depth": 3,
-    "order/order": null,
-    "order/properties-order": null,
-    "order/properties-alphabetical-order": null,
     "selector-class-pattern": "^[a-z][a-z0-9_-]*$",
   },
 };


### PR DESCRIPTION
Removed order-related rules from stylelint configuration.

These are not supported by newer versions of stylelint.